### PR TITLE
chore: Update from ubuntu-latest to goto-linux [DT-4647]

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ on: [push]
 jobs:
   build:
     name: My Build Job
-    runs-on: goto-linux
+    runs-on:
+      group: goto-linux
 
     steps:
       - name: Checkout Code

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ on: [push]
 jobs:
   build:
     name: My Build Job
-    runs-on: ubuntu-latest
+    runs-on: goto-linux
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
This PR updates all ubuntu-latest GitHub runners to the on-prem goto-linux GitHub runners.